### PR TITLE
temporary fix for the payment link

### DIFF
--- a/NCLL/dashboard.html
+++ b/NCLL/dashboard.html
@@ -129,7 +129,9 @@
 				<p>Total balance</p>
 				<p class="balance">$1375.15</p>
 				<p><a href="applications.html?filter=payment">Applications</a>: 0</p>
-				<p><a href="licences.html?filter=payment">Licence renewals</a>: 1</p>
+				<p><a href="licences.html?filter=active">Licence renewals</a>: 1</p>
+				<!-- fix this filter so that it only includes active licences with payment due over 0.
+					Currently all active licences have a non-zero payment due -->
 				<p class="border-top">To pay your invoices, see <a href="https://sms-sgs.ic.gc.ca/singleInvoice/index?lang=en_CA">Online payment</a>.</p>
 			</section>
 		</div>


### PR DESCRIPTION
I believe it is safe to merge, but I wanted to wait after the sessions this week.

All active licences in the mock-up have a payment due, so the fix is basic.

I can change it so that it calculates payment due != 0 && active, but that would require some changes in the HTML and the js.